### PR TITLE
Windows fix: add shellescape() around the command arguments

### DIFF
--- a/plugin/devdocs.vim
+++ b/plugin/devdocs.vim
@@ -13,9 +13,10 @@ function! s:Cmd() abort
 endfunction
 
 " Build the URL stub
-let s:stub = get(g:, "devdocs_open_command", <SID>Cmd()) . " 'https://devdocs.io/?q="
+let s:stub = get(g:, "devdocs_open_command", <SID>Cmd()) . ' '
 
 " Build the command
 command! -bang -nargs=* DD silent! call system(len(split(<q-args>, ' ')) == 0 ?
-            \ s:stub . (expand('<bang>') == "!" || get(g:, 'devdocs_enable_scoping', 0) == 1 ? '' : &filetype) . ' ' . expand('<cword>') . "'" : len(split(<q-args>, ' ')) == 1 ?
-            \ s:stub . (expand('<bang>') == "!" || get(g:, 'devdocs_enable_scoping', 0) == 1 ? '' : &filetype) . ' ' . <q-args> . "'" : s:stub . <q-args> . "'")
+            \ s:stub . shellescape("https://devdocs.io/?q=" . (expand('<bang>') == "!" || get(g:, 'devdocs_enable_scoping', 0) == 1 ? '' : &filetype) . ' ' . expand('<cword>')) : len(split(<q-args>, ' ')) == 1 ?
+            \ s:stub . shellescape("https://devdocs.io/?q=" . (expand('<bang>') == "!" || get(g:, 'devdocs_enable_scoping', 0) == 1 ? '' : &filetype) . ' ' . <q-args>): s:stub . shellescape("https://devdocs.io/?q=" . <q-args>))
+


### PR DESCRIPTION
Command arguments on Windows must be doublequoted: `cmd "args"`. `shellescape()` should handle that properly on different OS-es.